### PR TITLE
rename to scala-library-compat

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Several levels of contribution are possible!
 
 ### Report a missing case
 
-Create an issue [scala-collection-compat/issues](https://github.com/scala/scala-collection-compat/issues).
+Create an issue [scala-library-compat/issues](https://github.com/scala/scala-library-compat/issues).
 Embrace `diff`s to describe differences between the standard collections and
 the new collection:
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-scala-collection-compat
+scala-library-compat
 Copyright (c) 2002-2020 EPFL
 Copyright (c) 2011-2020 Lightbend, Inc.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,5 @@ import scalafix.sbt.ScalafixPlugin.autoImport.{scalafixDependencies, scalafixSem
 
 ### Contributing
 
-The migration tool is not exhaustive and we will continue to improve
-it over time. If you encounter a use case that’s not supported, please
-report it as described in the
-[contributing documentation](CONTRIBUTING.md#migration-tool).
+The migration tool is not exhaustive. Contributions of additional rewrites are welcome.  If you encounter a use case that’s not supported, please report it as described in the [contributing
+documentation](CONTRIBUTING.md#migration-tool).

--- a/build.sbt
+++ b/build.sbt
@@ -14,13 +14,13 @@ lazy val commonSettings = Seq(
                                                  |See the NOTICE file distributed with this work for
                                                  |additional information regarding copyright ownership.
                                                  |""".stripMargin)),
-  scalaModuleMimaPreviousVersion := Some("2.1.4")
+  scalaModuleMimaPreviousVersion := None  // TODO: change to `Some("3.0.0") once we publish
 )
 
 lazy val root = project
   .in(file("."))
   .settings(commonSettings)
-  .settings(name := "scala-collection-compat")
+  .settings(name := "scala-library-compat")
   .settings(dontPublish)
   .aggregate(
     compat211JVM,
@@ -56,8 +56,8 @@ lazy val compat = MultiScalaCrossProject(JSPlatform, JVMPlatform, NativePlatform
   _.settings(scalaModuleSettings)
     .settings(commonSettings)
     .settings(
-      name := "scala-collection-compat",
-      moduleName := "scala-collection-compat",
+      name := "scala-library-compat",
+      moduleName := "scala-library-compat",
       scalacOptions ++= Seq("-feature", "-language:higherKinds", "-language:implicitConversions"),
       unmanagedSourceDirectories in Compile += {
         val sharedSourceDir = (baseDirectory in ThisBuild).value / "compat/src/main"
@@ -72,7 +72,7 @@ lazy val compat = MultiScalaCrossProject(JSPlatform, JVMPlatform, NativePlatform
     .jsSettings(
       scalacOptions += {
         val x = (baseDirectory in LocalRootProject).value.toURI.toString
-        val y = "https://raw.githubusercontent.com/scala/scala-collection-compat/" + sys.process
+        val y = "https://raw.githubusercontent.com/scala/scala-library-compat/" + sys.process
           .Process("git rev-parse HEAD")
           .lineStream_!
           .head

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val commonSettings = Seq(
                                                  |See the NOTICE file distributed with this work for
                                                  |additional information regarding copyright ownership.
                                                  |""".stripMargin)),
-  scalaModuleMimaPreviousVersion := None  // TODO: change to `Some("3.0.0") once we publish
+  scalaModuleMimaPreviousVersion := None // TODO: change to `Some("3.0.0") once we publish
 )
 
 lazy val root = project
@@ -188,12 +188,14 @@ lazy val `scalafix-input` = project
   )
   .dependsOn(`scalafix-data212`)
 
-val `scalafix-output` = MultiScalaProject("scalafix-output",
-                                          "scalafix/output",
-                                          _.settings(sharedScalafixSettings)
-                                            .settings(commonSettings)
-                                            .settings(dontPublish)
-                                            .disablePlugins(ScalafixPlugin))
+val `scalafix-output` = MultiScalaProject(
+  "scalafix-output",
+  "scalafix/output",
+  _.settings(sharedScalafixSettings)
+    .settings(commonSettings)
+    .settings(dontPublish)
+    .disablePlugins(ScalafixPlugin)
+)
 
 lazy val outputCross =
   Def.setting((baseDirectory in ThisBuild).value / "scalafix/output/src/main/scala")
@@ -243,10 +245,12 @@ lazy val `scalafix-tests` = project
   .settings(
     scalaVersion := scalafixScala212,
     libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % scalafixVersion % Test cross CrossVersion.full,
-    scalafixTestkitOutputSourceDirectories := Seq(outputCross.value,
-                                                  output212.value,
-                                                  output212Plus.value,
-                                                  output213.value),
+    scalafixTestkitOutputSourceDirectories := Seq(
+      outputCross.value,
+      output212.value,
+      output212Plus.value,
+      output213.value
+    ),
     scalafixTestkitInputSourceDirectories := sourceDirectories.in(`scalafix-input`, Compile).value,
     scalafixTestkitInputClasspath := fullClasspath.in(`scalafix-input`, Compile).value
   )
@@ -258,7 +262,7 @@ lazy val dontPublish = Seq(
   packagedArtifacts := Map.empty,
   publish := {},
   publishLocal := {},
-  scalaModuleMimaPreviousVersion := None,
+  scalaModuleMimaPreviousVersion := None
 )
 
 val travisScalaVersion = sys.env.get("TRAVIS_SCALA_VERSION").flatMap(Version.parse)
@@ -333,7 +337,7 @@ inThisBuild(
                 s"$projectPrefix/publishSigned",
                 "sonatypePrepare",
                 "sonatypeBundleUpload",
-                "sonatypeClose",
+                "sonatypeClose"
               )
             } else {
               Nil
@@ -355,4 +359,5 @@ inThisBuild(
       val newCommands = toRun.toList.map(Exec(_, None))
       state.copy(remainingCommands = newCommands ::: state.remainingCommands)
     }
-  ))
+  )
+)


### PR DESCRIPTION
fixes #317

note that I already renamed the GitHub repo

#328 has the associated README.md changes separately, to be
merged once we've actually published under the new name

this PR disables MiMa, but I left a breadcrumb in #328 to remember to re-enable it later