### PR TITLE
`scala.collection.Map.foreachEntry` backport for 2.11/2.12

### DIFF
--- a/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
+++ b/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
@@ -177,6 +177,10 @@ private[compat] trait PackageShared {
   type IterableOnce[+X] = c.TraversableOnce[X]
   val IterableOnce = c.TraversableOnce
 
+  implicit def toMapExtensionMethods[K, V](
+      self: scala.collection.Map[K, V]): MapExtensionMethods[K, V] =
+    new MapExtensionMethods[K, V](self)
+
   implicit def toMapViewExtensionMethods[K, V, C <: scala.collection.Map[K, V]](
       self: IterableView[(K, V), C]): MapViewExtensionMethods[K, V, C] =
     new MapViewExtensionMethods[K, V, C](self)
@@ -391,6 +395,14 @@ class Tuple2ZippedExtensionMethods[El1, Repr1, El2, Repr2](
   def lazyZip[El3, Repr3, T3](t3: T3)(implicit w3: T3 => IterableLike[El3, Repr3])
     : Tuple3Zipped[El1, Repr1, El2, Repr2, El3, Repr3] =
     new Tuple3Zipped((self.colls._1, self.colls._2, t3))
+}
+
+class MapExtensionMethods[K, V](private val self: scala.collection.Map[K, V]) extends AnyVal {
+
+  def foreachEntry[U](f: (K, V) => U): Unit = {
+    self.foreach { case (k, v) => f(k, v) }
+  }
+
 }
 
 class MapViewExtensionMethods[K, V, C <: scala.collection.Map[K, V]](

--- a/compat/src/test/scala/test/scala/collection/MapTest.scala
+++ b/compat/src/test/scala/test/scala/collection/MapTest.scala
@@ -1,0 +1,29 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+package test.scala.collection
+
+import org.junit.Test
+import org.junit.Assert._
+
+import scala.collection.compat._
+
+class MapTest {
+
+  @Test
+  def foreachEntry: Unit = {
+    val map  = Map("a" -> 1, "b" -> 2, "c" -> 3)
+    var copy = Map.empty[String, Int]
+    map.foreachEntry((k, v) => copy += k -> v)
+    assertEquals(map, copy)
+  }
+
+}


### PR DESCRIPTION
Fixes #335.